### PR TITLE
Fix isHTTPS false positive when forwarding cleartext requests

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -38,6 +38,13 @@ func isHTTPS(r *http.Request, acceptXForwardedProtoHeader bool) bool {
 	if acceptXForwardedProtoHeader && r.Header.Get("X-Forwarded-Proto") == "https" {
 		return true
 	}
+
+	// Give preference to the X-Forwarded-Proto from upstream if its
+	// handling a cleartext request
+	if acceptXForwardedProtoHeader && r.Header.Get("X-Forwarded-Proto") == "http" {
+		return false
+	}
+
 	// Set by some middleware.
 	if r.URL.Scheme == "https" {
 		return true

--- a/handler.go
+++ b/handler.go
@@ -34,17 +34,14 @@ func NewHandler(next http.Handler) *Handler {
 }
 
 func isHTTPS(r *http.Request, acceptXForwardedProtoHeader bool) bool {
-	// Added by common load balancers which do SSL offloading.
+	// Added by common load balancers which do TLS offloading.
 	if acceptXForwardedProtoHeader && r.Header.Get("X-Forwarded-Proto") == "https" {
 		return true
 	}
-
-	// Give preference to the X-Forwarded-Proto from upstream if its
-	// handling a cleartext request
+	// If the X-Forwarded-Proto was set upstream as HTTP, then the request came in without TLS.
 	if acceptXForwardedProtoHeader && r.Header.Get("X-Forwarded-Proto") == "http" {
 		return false
 	}
-
 	// Set by some middleware.
 	if r.URL.Scheme == "https" {
 		return true
@@ -53,7 +50,6 @@ func isHTTPS(r *http.Request, acceptXForwardedProtoHeader bool) bool {
 	if r.TLS != nil && r.TLS.HandshakeComplete {
 		return true
 	}
-
 	return false
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -123,6 +123,18 @@ func TestThatTLSIsUsedToDetermineSSLStatus(t *testing.T) {
 	}
 }
 
+func TestThatTLSDoesNotOverrideHTTPHeadersToDetermineSSLStatus(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.TLS = &tls.ConnectionState{
+		HandshakeComplete: true,
+	}
+	r.Header.Add("X-Forwarded-Proto", "http")
+
+	if isHTTPS(r, true) {
+		t.Error("The request was HTTPS but was declared HTTP by the header, but this was overruled")
+	}
+}
+
 func TestThatTheHostCanBeOverridden(t *testing.T) {
 	// Create the handler to wrap.
 	wrappedHandler := &TestHandler{

--- a/handler_test.go
+++ b/handler_test.go
@@ -131,7 +131,7 @@ func TestThatTLSDoesNotOverrideHTTPHeadersToDetermineSSLStatus(t *testing.T) {
 	r.Header.Add("X-Forwarded-Proto", "http")
 
 	if isHTTPS(r, true) {
-		t.Error("The request was HTTPS but was declared HTTP by the header, but this was overruled")
+		t.Error("The request from the load balancer to the service was HTTPS, but the request from the user to the load balancer was HTTP.")
 	}
 }
 


### PR DESCRIPTION
In the following scenario:
1. Golang service is configured to accept TLS connections
2. Golang service is being served behind a reverse proxy that forwards connections over HTTPS
3. A cleartext client connects to the service via the reverse proxy

the `isHTTPS` function middleware would return a false positive response causing a) the client to not be redirected to the HTTPS version of the page that they're requesting and b) the HSTS headers to be sent in the clear causing them to be dropped.

This PR fixes `isHTTPS` such that it always gives preference to the `X-Forwarded-For` header which more accurately describes the state of the client connection. 